### PR TITLE
Bump lombok to address compile problem seen with openjdk 18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.2</version>
+            <version>1.18.22</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
I am unsure if it's desired to upgrade deps on this project, but sharing for others who may hit this problem.
I wasn't able to compile the project on openjdk 18, I needed to upgrade lombok then compiled OK.

Fixes #1 
